### PR TITLE
Fix zero reference count for Go methods with receivers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - _No changes yet_
 
 ### Fixed
+- Fixed zero reference count for Go methods with receivers (e.g. `func (c *Client) doWithRetry(...)`) by using `selectionRange` for accurate symbol positioning and handling qualified names from gopls (e.g. `(*Client).doWithRetry`)
 - Faster startup time and more efficient caching by replacing gitignored caching from eager & bulk to lazy and per-file. This solves issues with large repos where initial caching could take a long time.
 
 ### Breaking

--- a/lua/lensline/lens_explorer.lua
+++ b/lua/lensline/lens_explorer.lua
@@ -328,14 +328,16 @@ function M.extract_symbols_recursive(symbols, functions, start_line, end_line)
         local end_line_num
         local character
 
-        -- Handle both DocumentSymbol and SymbolInformation formats
         if symbol.range then
-          -- DocumentSymbol format
-          line_num = symbol.range.start.line + 1 -- Convert to 1-indexed
-          end_line_num = symbol.range["end"].line + 1 -- Convert to 1-indexed
-          character = symbol.range.start.character
+          line_num = symbol.range.start.line + 1
+          end_line_num = symbol.range["end"].line + 1
+          -- selectionRange points to the symbol name, not the full declaration
+          if symbol.selectionRange then
+            character = symbol.selectionRange.start.character
+          else
+            character = symbol.range.start.character
+          end
         elseif symbol.location then
-          -- SymbolInformation format
           line_num = symbol.location.range.start.line + 1
           end_line_num = symbol.location.range["end"].line + 1
           character = symbol.location.range.start.character

--- a/lua/lensline/utils.lua
+++ b/lua/lensline/utils.lua
@@ -80,7 +80,32 @@ function M.get_function_lines(bufnr, func_info)
     return vim.api.nvim_buf_get_lines(bufnr, start_line - 1, estimated_end, false)
 end
 
--- LSP Utilities
+local function resolve_func_char_pos(bufnr, func_info)
+    local debug = require("lensline.debug")
+    local char_pos = func_info.character or 0
+
+    if func_info.name then
+        local line_content = vim.api.nvim_buf_get_lines(bufnr, func_info.line - 1, func_info.line, false)[1] or ""
+        local search_name = func_info.name
+        local name_start = line_content:find(search_name, 1, true)
+        -- qualified name (e.g. "(*Client).doWithRetry") — try short name after last dot
+        if not name_start then
+            local short_name = search_name:match("%.([^%.]+)$")
+            if short_name then
+                name_start = line_content:find(short_name, 1, true)
+                if name_start then
+                    debug.log_context("LSP", "used short name '" .. short_name .. "' from qualified '" .. search_name .. "' at character " .. (name_start - 1))
+                end
+            end
+        end
+        if name_start then
+            char_pos = name_start - 1  -- Convert to 0-indexed
+            debug.log_context("LSP", "resolved function name '" .. func_info.name .. "' at character " .. char_pos)
+        end
+    end
+
+    return char_pos
+end
 
 function M.has_lsp_references_capability(bufnr)
     local lens_explorer = require("lensline.lens_explorer")
@@ -103,17 +128,7 @@ function M.get_lsp_references(bufnr, func_info, callback)
     end
     
     -- Resolve function position
-    local char_pos = func_info.character or 0
-    
-    -- If we have a function name, try to find its exact position in the line
-    if func_info.name then
-        local line_content = vim.api.nvim_buf_get_lines(bufnr, func_info.line - 1, func_info.line, false)[1] or ""
-        local name_start = line_content:find(func_info.name, 1, true)
-        if name_start then
-            char_pos = name_start - 1  -- Convert to 0-indexed
-            debug.log_context("LSP", "found function name '" .. func_info.name .. "' at character " .. char_pos)
-        end
-    end
+    local char_pos = resolve_func_char_pos(bufnr, func_info)
     
     -- Create LSP reference request
     local params = {
@@ -181,17 +196,7 @@ function M.get_lsp_definitions(bufnr, func_info, callback)
     end
     
     -- Resolve function position
-    local char_pos = func_info.character or 0
-    
-    -- If we have a function name, try to find its exact position in the line
-    if func_info.name then
-        local line_content = vim.api.nvim_buf_get_lines(bufnr, func_info.line - 1, func_info.line, false)[1] or ""
-        local name_start = line_content:find(func_info.name, 1, true)
-        if name_start then
-            char_pos = name_start - 1  -- Convert to 0-indexed
-            debug.log_context("LSP", "found function name '" .. func_info.name .. "' at character " .. char_pos)
-        end
-    end
+    local char_pos = resolve_func_char_pos(bufnr, func_info)
     
     -- Create LSP definition request
     local params = {
@@ -225,17 +230,7 @@ function M.get_lsp_implementations(bufnr, func_info, callback)
     end
     
     -- Resolve function position
-    local char_pos = func_info.character or 0
-    
-    -- If we have a function name, try to find its exact position in the line
-    if func_info.name then
-        local line_content = vim.api.nvim_buf_get_lines(bufnr, func_info.line - 1, func_info.line, false)[1] or ""
-        local name_start = line_content:find(func_info.name, 1, true)
-        if name_start then
-            char_pos = name_start - 1  -- Convert to 0-indexed
-            debug.log_context("LSP", "found function name '" .. func_info.name .. "' at character " .. char_pos)
-        end
-    end
+    local char_pos = resolve_func_char_pos(bufnr, func_info)
     
     -- Create LSP implementation request
     local params = {

--- a/tests/unit/test_qualified_name_resolution_spec.lua
+++ b/tests/unit/test_qualified_name_resolution_spec.lua
@@ -1,0 +1,200 @@
+local eq = assert.are.same
+
+local function reset_modules()
+  for name, _ in pairs(package.loaded) do
+    if name:match("^lensline") then package.loaded[name] = nil end
+  end
+end
+
+describe("lens_explorer.extract_symbols_recursive selectionRange support", function()
+  before_each(reset_modules)
+  after_each(reset_modules)
+
+  it("uses selectionRange.start.character when available", function()
+    local lens_explorer = require("lensline.lens_explorer")
+
+    -- gopls DocumentSymbol for: func (c *Client) doWithRetry(...)
+    local symbols = {
+      {
+        name = "(*Client).doWithRetry",
+        kind = vim.lsp.protocol.SymbolKind.Method,
+        range = {
+          start = { line = 10, character = 0 },
+          ["end"] = { line = 30, character = 1 },
+        },
+        selectionRange = {
+          start = { line = 10, character = 22 },
+          ["end"] = { line = 10, character = 33 },
+        },
+      },
+    }
+
+    local functions = {}
+    lens_explorer.extract_symbols_recursive(symbols, functions, 1, 50)
+
+    eq(1, #functions)
+    eq("(*Client).doWithRetry", functions[1].name)
+    eq(11, functions[1].line)
+    eq(22, functions[1].character, "should use selectionRange character, not range character")
+  end)
+
+  it("falls back to range.start.character when selectionRange is absent", function()
+    local lens_explorer = require("lensline.lens_explorer")
+
+    local symbols = {
+      {
+        name = "doSomething",
+        kind = vim.lsp.protocol.SymbolKind.Function,
+        range = {
+          start = { line = 5, character = 4 },
+          ["end"] = { line = 10, character = 1 },
+        },
+      },
+    }
+
+    local functions = {}
+    lens_explorer.extract_symbols_recursive(symbols, functions, 1, 20)
+
+    eq(1, #functions)
+    eq(4, functions[1].character, "should fall back to range.start.character")
+  end)
+end)
+
+describe("utils qualified name resolution", function()
+  local utils
+  local created_buffers = {}
+
+  local function make_buf(lines)
+    local bufnr = vim.api.nvim_create_buf(false, true)
+    table.insert(created_buffers, bufnr)
+    if lines and #lines > 0 then
+      vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
+    end
+    return bufnr
+  end
+
+  local orig_lsp = {}
+
+  before_each(function()
+    reset_modules()
+    utils = require("lensline.utils")
+    created_buffers = {}
+    orig_lsp = {}
+  end)
+
+  after_each(function()
+    for _, bufnr in ipairs(created_buffers) do
+      if vim.api.nvim_buf_is_valid(bufnr) then
+        vim.api.nvim_buf_delete(bufnr, { force = true })
+      end
+    end
+    for key, fn in pairs(orig_lsp) do
+      vim.lsp[key] = fn
+    end
+    reset_modules()
+  end)
+
+  local function stub_lsp_for_references(response)
+    orig_lsp.get_clients = vim.lsp.get_clients
+    orig_lsp.get_active_clients = vim.lsp.get_active_clients
+    orig_lsp.buf_request = vim.lsp.buf_request
+
+    local mock_client = {
+      name = "gopls",
+      server_capabilities = { referencesProvider = true, documentSymbolProvider = true },
+    }
+    vim.lsp.get_clients = function(_) return { mock_client } end
+    vim.lsp.get_active_clients = function(_) return { mock_client } end
+
+    local captured_params = nil
+    vim.lsp.buf_request = function(bufnr, method, params, handler)
+      if method == "textDocument/references" then
+        captured_params = params
+        handler(nil, response, {})
+      end
+    end
+
+    return function() return captured_params end
+  end
+
+  it("resolves short name from qualified gopls method name", function()
+    local bufnr = make_buf({
+      "func (c *Client) doWithRetry(ctx context.Context, buildReq func() (*http.Request, error)) ([]byte, error) {",
+    })
+
+    local func_info = {
+      line = 1,
+      character = 0,
+      name = "(*Client).doWithRetry",
+    }
+
+    local mock_refs = {
+      { uri = "file:///test.go", range = { start = { line = 50, character = 10 } } },
+      { uri = "file:///test.go", range = { start = { line = 60, character = 10 } } },
+      { uri = "file:///test.go", range = { start = { line = 70, character = 10 } } },
+    }
+
+    local get_params = stub_lsp_for_references(mock_refs)
+
+    local result = nil
+    utils.get_lsp_references(bufnr, func_info, function(refs)
+      result = refs
+    end)
+
+    eq(3, result and #result or 0, "should find 3 references")
+
+    local params = get_params()
+    assert.is_not_nil(params, "LSP request should have been made")
+    -- "func (c *Client) doWithRetry..." -> "doWithRetry" starts at col 17
+    eq(17, params.position.character, "should resolve to 'doWithRetry', not 'func'")
+  end)
+
+  it("works with non-qualified function names", function()
+    local bufnr = make_buf({
+      "func doRequest(httpClient *http.Client, req *http.Request) ([]byte, error) {",
+    })
+
+    local func_info = {
+      line = 1,
+      character = 0,
+      name = "doRequest",
+    }
+
+    local mock_refs = {
+      { uri = "file:///test.go", range = { start = { line = 50, character = 10 } } },
+    }
+
+    local get_params = stub_lsp_for_references(mock_refs)
+
+    local result = nil
+    utils.get_lsp_references(bufnr, func_info, function(refs)
+      result = refs
+    end)
+
+    eq(1, result and #result or 0)
+
+    local params = get_params()
+    assert.is_not_nil(params)
+    eq(5, params.position.character, "should resolve to 'doRequest' position")
+  end)
+
+  it("uses func_info.character as last resort when name not found in line", function()
+    local bufnr = make_buf({
+      "some unrelated line content",
+    })
+
+    local func_info = {
+      line = 1,
+      character = 7,
+      name = "nonExistentFunction",
+    }
+
+    local get_params = stub_lsp_for_references({})
+
+    utils.get_lsp_references(bufnr, func_info, function(_) end)
+
+    local params = get_params()
+    assert.is_not_nil(params)
+    eq(7, params.position.character, "should fall back to func_info.character")
+  end)
+end)


### PR DESCRIPTION
Hi! Was using this plugin while writing golang and noticed that methods with receivers always show 0 references. Dug into it and found the cause.

## Problem

For Go methods like:

```go
func (c *Client) doWithRetry(ctx context.Context, ...) ([]byte, error) {
```

the lens always shows `0 references` even when there are clearly usages in the codebase.

What happens is gopls returns these symbols with qualified names like `(*Client).doWithRetry`, and `range.start.character` points to column 0 (the `func` keyword) instead of the actual method name. So when lensline asks LSP for references at that position, it's asking about `func` — which nothing references.

## Fix

1. **Use `selectionRange` for character position** — LSP `DocumentSymbol` has a `selectionRange` that points to the symbol name specifically, not the full declaration. `extract_symbols_recursive` now prefers `selectionRange.start.character` when available, falls back to `range.start.character` for servers that don't provide it.

2. **Handle qualified names** — When resolving cursor position, if the full qualified name (`(*Client).doWithRetry`) isn't found on the line, extract the short name after the last dot (`doWithRetry`) and search for that. This lands on the correct column.

3. **DRY refactor** — The same 10-line position resolution block was duplicated in `get_lsp_references`, `get_lsp_definitions`, and `get_lsp_implementations`. Pulled it into a single `resolve_func_char_pos` function.

## Changed files

- `lua/lensline/lens_explorer.lua` — selectionRange support in `extract_symbols_recursive`
- `lua/lensline/utils.lua` — new `resolve_func_char_pos` replaces 3 duplicated blocks, handles qualified names
- `tests/unit/test_qualified_name_resolution_spec.lua` — tests for selectionRange, qualified names, plain names, fallback

All 311 tests pass.