### PR TITLE
v2.1.0: Per-highlight support for providers and results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ luac.out
 *.hex
 
 TODO.md
+.todo/
 
 # --- Test infrastructure (local only, not published) ---
 tests/tmp/

--- a/.luarc.json
+++ b/.luarc.json
@@ -1,0 +1,11 @@
+{
+  "runtime": {
+    "version": "LuaJIT"
+  },
+  "workspace": {
+    "library": [
+      "${3rd}/luassert/library"
+    ],
+    "checkThirdParty": false
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed zero reference count for Go methods with receivers (e.g. `func (c *Client) doWithRetry(...)`) by using `selectionRange` for accurate symbol positioning and handling qualified names from gopls (e.g. `(*Client).doWithRetry`)
-- Faster startup time and more efficient caching by replacing gitignored caching from eager & bulk to lazy and per-file. This solves issues with large repos where initial caching could take a long time.
+- _No changes yet_
 
 ### Breaking
 - _No changes yet_
+
+## [v2.1.0] - 2026-04-16
+
+### Added
+- **Per-highlight support**: Different highlight groups per provider and per result, instead of one global `style.highlight`
+  - Provider-level: set `highlight = "SomeHl"` in provider config to color all its results
+  - Result-level: provider callbacks can return `highlight` per item to override the provider highlight
+  - Fallback chain: result highlight → provider config highlight → global `style.highlight`
+  - Separator and prefix always use global `style.highlight`
+  - Fully backward compatible — existing configs without highlight customization behave identically
+
+### Fixed
+- Faster startup time and more efficient caching by replacing gitignored caching from eager & bulk to lazy and per-file. This solves issues with large repos where initial caching could take a long time.
 
 ## [v2.0.0] - 2025-09-27
 

--- a/README.md
+++ b/README.md
@@ -151,12 +151,13 @@ lensline.nvim works out of the box with sensible defaults. You can customize it 
               name = "last_author",
               enabled = true,         -- enabled by default with caching optimization
               cache_max_files = 50,   -- maximum number of files to cache blame data for (default: 50)
+              highlight = "String",   -- optional: override style.highlight for this provider
             },
             -- additional built-in or custom providers can be added here
           },
           style = {
             separator = " • ",      -- separator between all lens attributes
-            highlight = "Comment",  -- highlight group for lens text
+            highlight = "Comment",  -- default highlight group for lens text (providers can override)
             prefix = "┃ ",         -- prefix before lens content
             placement = "above",    -- "above" | "inline" - where to render lenses (consider prefix = "" for inline)
             use_nerdfont = true,    -- enable nerd font icons in built-in providers
@@ -224,6 +225,41 @@ For a more subtle, distraction-free experience, try this minimal configuration t
   end,
 }
 ```
+
+</details>
+
+<details>
+<summary><strong>Per-Provider Highlights</strong> - Different colors for each provider</summary>
+
+Each provider can have its own highlight group, making it easy to visually distinguish between different types of information:
+
+```lua
+{
+  'oribarilan/lensline.nvim',
+  branch = 'release/2.x',
+  event = 'LspAttach',
+  config = function()
+    require('lensline').setup {
+      profiles = {
+        {
+          name = 'colorful',
+          providers = {
+            { name = 'usages', enabled = true, highlight = 'Function' },
+            { name = 'last_author', enabled = true, highlight = 'String' },
+          },
+          style = {
+            highlight = 'Comment', -- fallback for providers without a highlight
+          },
+        },
+      },
+    }
+  end,
+}
+```
+
+The highlight fallback chain is: result-level highlight (from provider callback) -> provider config `highlight` -> global `style.highlight`.
+
+Custom providers can also return per-result highlights via the callback (see [providers.md](providers.md)).
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Using [lazy.nvim](https://github.com/folke/lazy.nvim):
 ```lua
 {
   'oribarilan/lensline.nvim',
-  tag = '2.0.0', -- or: branch = 'release/2.x' for latest non-breaking updates
+  tag = '2.1.0', -- or: branch = 'release/2.x' for latest non-breaking updates
   event = 'LspAttach',
   config = function()
     require("lensline").setup()
@@ -89,7 +89,7 @@ Plug 'oribarilan/lensline.nvim', { 'branch': 'release/1.x' }
 ```lua
 use {
     'oribarilan/lensline.nvim',
-    tag = '2.0.0', -- or: branch = 'release/2.x' for latest non-breaking updates
+    tag = '2.1.0', -- or: branch = 'release/2.x' for latest non-breaking updates
 }
 ```
 </details>

--- a/lua/lensline/presenter.lua
+++ b/lua/lensline/presenter.lua
@@ -1,20 +1,25 @@
 local M = {}
 
--- Combine provider data with proper ordering preservation
--- This consolidates the duplicate combination logic from renderer.lua and focused_renderer.lua
+local function resolve_highlight(item_highlight, provider_highlight)
+  if item_highlight and item_highlight ~= "" then
+    return item_highlight
+  end
+  if provider_highlight and provider_highlight ~= "" then
+    return provider_highlight
+  end
+  return nil
+end
+
 function M.combine_provider_data(provider_lens_data, provider_configs)
   local combined = {}
-  if not provider_lens_data then 
-    return combined 
+  if not provider_lens_data then
+    return combined
   end
-  
-  -- Critical: preserve config order for consistent display sequence
+
   for _, provider_config in ipairs(provider_configs) do
     if provider_config.enabled ~= false then
       local lens_items = provider_lens_data[provider_config.name]
       if lens_items and type(lens_items) == "table" then
-        -- Handle sparse arrays (preserving existing renderer.lua logic)
-        -- This robust iteration handles nil gaps while preserving numeric order
         local numeric_indices = {}
         for k, _ in pairs(lens_items) do
           if type(k) == "number" then
@@ -22,64 +27,89 @@ function M.combine_provider_data(provider_lens_data, provider_configs)
           end
         end
         table.sort(numeric_indices)
-        
+
         for _, idx in ipairs(numeric_indices) do
           local item = lens_items[idx]
           if item and item.line and item.text and item.text ~= "" then
             combined[item.line] = combined[item.line] or {}
-            table.insert(combined[item.line], item.text)
+            table.insert(combined[item.line], {
+              text = item.text,
+              highlight = resolve_highlight(item.highlight, provider_config.highlight)
+            })
           end
         end
       end
     end
   end
-  
-  return combined -- { [1-based line] = { "txt1", "txt2", ... } }
+
+  return combined
 end
 
--- Complete extmark options builder that consolidates all duplication
--- Replaces create_extmark_opts() from renderer.lua and make_opts() from focused_renderer.lua
-function M.compute_extmark_opts(args)
-  -- args: { placement, texts, separator, highlight, prefix, line_content, ephemeral }
-  local placement = args.placement or "above"
-  local combined_text = table.concat(args.texts or {}, args.separator or " • ")
-  local highlight = args.highlight or "Comment"
-  local prefix = args.prefix or ""
-  
-  if placement == "inline" then
-    -- Inline: virtual text at end of line, with prefix if configured
-    local virt_text = {}
-    
-    -- Add prefix if configured
-    if prefix ~= "" then
-      table.insert(virt_text, { prefix, highlight })
+local function build_content_chunks(texts, separator, global_hl)
+  local chunks = {}
+  for i, entry in ipairs(texts) do
+    if i > 1 then
+      table.insert(chunks, { separator, global_hl })
     end
-    
-    table.insert(virt_text, { combined_text, highlight })
-    
-    -- Combine all parts into a single string with a leading space
-    local inline_text = " " .. table.concat(vim.tbl_map(function(t) return t[1] end, virt_text), "")
-    
+    local text, hl
+    if type(entry) == "table" then
+      text = entry.text or ""
+      hl = entry.highlight or global_hl
+    else
+      text = entry
+      hl = global_hl
+    end
+    table.insert(chunks, { text, hl })
+  end
+  return chunks
+end
+
+function M.compute_extmark_opts(args)
+  local placement = args.placement or "above"
+  local global_hl = args.highlight or "Comment"
+  local prefix = args.prefix or ""
+  local separator = args.separator or " • "
+  local texts = args.texts or {}
+
+  local chunks = build_content_chunks(texts, separator, global_hl)
+
+  if placement == "inline" then
+    local virt_text = {}
+    local leader = " "
+    if prefix ~= "" then
+      leader = leader .. prefix
+    end
+    table.insert(virt_text, { leader, global_hl })
+    for _, chunk in ipairs(chunks) do
+      table.insert(virt_text, chunk)
+    end
+
     return {
-      virt_text = { { inline_text, highlight } },
+      virt_text = virt_text,
       virt_text_pos = "eol",
       hl_mode = "combine",
       ephemeral = args.ephemeral or false
     }
   else
-    -- Above: virtual lines above function, with prefix and indentation
-    -- Preserve exact indentation logic from current implementations
     local leading_whitespace = (args.line_content or ""):match("^%s*") or ""
     local virt_text = {}
-    
+
     if leading_whitespace ~= "" then
-      table.insert(virt_text, { leading_whitespace, highlight })
+      table.insert(virt_text, { leading_whitespace, global_hl })
     end
-    
-    -- Combine prefix with text as single entry for consistency
-    local display_text = prefix .. combined_text
-    table.insert(virt_text, { display_text, highlight })
-    
+
+    if prefix ~= "" then
+      table.insert(virt_text, { prefix, global_hl })
+    end
+
+    for _, chunk in ipairs(chunks) do
+      table.insert(virt_text, chunk)
+    end
+
+    if #virt_text == 0 then
+      table.insert(virt_text, { "", global_hl })
+    end
+
     return {
       virt_lines = { virt_text },
       virt_lines_above = true,

--- a/providers.md
+++ b/providers.md
@@ -32,7 +32,8 @@ return {
     -- Always call callback with lens item or nil
     callback({
       line = func_info.line,
-      text = "💩 " .. custom_data
+      text = "💩 " .. custom_data,
+      highlight = "DiagnosticWarn", -- optional: override highlight for this result
     })
     -- or callback(nil) if no lens should be shown
   end
@@ -43,7 +44,7 @@ return {
 
 - **Parameters**: `(bufnr, func_info, provider_config, callback)`
 - **Return**: Nothing (always use callback)
-- **Callback**: Called with lens item `{ line = number, text = string }` or `nil`
+- **Callback**: Called with lens item `{ line = number, text = string, highlight = string? }` or `nil`
 - **provider_config**: Contains this provider's configuration options
 - **Debug logging**: Automatic - no need to add debug logging in provider handlers
 
@@ -61,6 +62,28 @@ The `func_info` parameter contains:
 - Function definition spans beyond the processed range
 
 Always check if it exists before using it. The [`utils.get_function_lines()`](lua/lensline/utils.lua) utility handles this automatically with fallback logic.
+
+### Per-Result Highlights
+
+Provider callbacks can optionally include a `highlight` field in their result to override the highlight group for that specific lens item. This is useful for providers that want to use different colors based on the result (e.g., red for high complexity, green for low).
+
+```lua
+handler = function(bufnr, func_info, provider_config, callback)
+  local severity = get_severity(func_info)
+  callback({
+    line = func_info.line,
+    text = severity .. " severity",
+    highlight = severity == "high" and "DiagnosticError" or "DiagnosticOk",
+  })
+end
+```
+
+The highlight fallback chain is:
+1. Result `highlight` (from callback) -- per-item override
+2. Provider config `highlight` (from setup) -- per-provider default
+3. Global `style.highlight` -- fallback for all providers
+
+Omitting `highlight` or setting it to `""` falls back to the next level in the chain.
 
 ### Utility Functions
 

--- a/tests/unit/test_focused_rendering_spec.lua
+++ b/tests/unit/test_focused_rendering_spec.lua
@@ -201,9 +201,9 @@ describe("focused rendering system", function()
           }
         },
         expected = {
-          [10] = {"A", "B"},
-          [11] = {"D"},
-          [12] = {"C"}
+          [10] = {{ text = "A" }, { text = "B" }},
+          [11] = {{ text = "D" }},
+          [12] = {{ text = "C" }}
         }
       },
       {
@@ -226,7 +226,7 @@ describe("focused rendering system", function()
           }
         },
         expected = {
-          [10] = {"Valid"}
+          [10] = {{ text = "Valid" }}
         }
       }
     }

--- a/tests/unit/test_placement_spec.lua
+++ b/tests/unit/test_placement_spec.lua
@@ -443,8 +443,9 @@ describe("placement configuration", function()
       
       -- Verify text content
       local virt_text = details.virt_text
-      eq(1, #virt_text, "should have exactly one virt_text entry")
-      eq(" 5 refs", virt_text[1][1], "should have correct text with leading space")
+      eq(2, #virt_text, "should have leader and content virt_text entries")
+      eq(" ", virt_text[1][1], "should have leading space")
+      eq("5 refs", virt_text[2][1], "should have correct text content")
     end)
     
     it("should create correct extmark properties for above placement", function()

--- a/tests/unit/test_presenter_spec.lua
+++ b/tests/unit/test_presenter_spec.lua
@@ -1,16 +1,12 @@
--- tests/unit/test_presenter_spec.lua
--- unit tests for lensline.presenter (data combination and extmark options)
-
 local eq = assert.are.same
 
--- minimal debug stub to avoid noise
 package.loaded["lensline.debug"] = { log_context = function() end }
 
 describe("presenter", function()
   local function reset_modules()
     for name,_ in pairs(package.loaded) do
-      if name:match("^lensline") and name ~= "lensline.debug" then 
-        package.loaded[name] = nil 
+      if name:match("^lensline") and name ~= "lensline.debug" then
+        package.loaded[name] = nil
       end
     end
   end
@@ -24,7 +20,6 @@ describe("presenter", function()
   end)
 
   describe("combine_provider_data", function()
-    -- table-driven tests for edge cases
     for _, tc in ipairs({
       { name = "nil data", input = nil, providers = {}, expected = {} },
       { name = "empty data", input = {}, providers = {}, expected = {} },
@@ -48,17 +43,17 @@ describe("presenter", function()
           { line = 2, text = "A2" }
         }
       }
-      
+
       local provider_configs = {
         { name = "provider_a", enabled = true },
         { name = "provider_b", enabled = true }
       }
-      
+
       local result = presenter.combine_provider_data(provider_lens_data, provider_configs)
-      
+
       eq({
-        [1] = { "A1", "B1" },
-        [2] = { "A2", "B2" }
+        [1] = { { text = "A1" }, { text = "B1" } },
+        [2] = { { text = "A2" }, { text = "B2" } }
       }, result)
     end)
 
@@ -72,16 +67,16 @@ describe("presenter", function()
           { line = 1, text = "disabled" }
         }
       }
-      
+
       local provider_configs = {
         { name = "enabled_provider", enabled = true },
         { name = "disabled_provider", enabled = false }
       }
-      
+
       local result = presenter.combine_provider_data(provider_lens_data, provider_configs)
-      
+
       eq({
-        [1] = { "enabled" }
+        [1] = { { text = "enabled" } }
       }, result)
     end)
 
@@ -94,15 +89,15 @@ describe("presenter", function()
           [5] = { line = 1, text = "fifth" }
         }
       }
-      
+
       local provider_configs = {
         { name = "sparse_provider", enabled = true }
       }
-      
+
       local result = presenter.combine_provider_data(provider_lens_data, provider_configs)
-      
+
       eq({
-        [1] = { "first", "third", "fifth" }
+        [1] = { { text = "first" }, { text = "third" }, { text = "fifth" } }
       }, result)
     end)
 
@@ -111,22 +106,22 @@ describe("presenter", function()
       local provider_lens_data = {
         mixed_provider = {
           { line = 1, text = "valid" },
-          { line = 1 }, -- missing text
-          { text = "missing_line" }, -- missing line
+          { line = 1 },
+          { text = "missing_line" },
           { line = 1, text = "also_valid" },
-          nil, -- nil item
-          { line = 1, text = "" } -- empty text
+          nil,
+          { line = 1, text = "" }
         }
       }
-      
+
       local provider_configs = {
         { name = "mixed_provider", enabled = true }
       }
-      
+
       local result = presenter.combine_provider_data(provider_lens_data, provider_configs)
-      
+
       eq({
-        [1] = { "valid", "also_valid" }
+        [1] = { { text = "valid" }, { text = "also_valid" } }
       }, result)
     end)
 
@@ -140,18 +135,77 @@ describe("presenter", function()
           { line = 3, text = "line3_only" }
         }
       }
-      
+
       local provider_configs = {
         { name = "multi_provider", enabled = true }
       }
-      
+
       local result = presenter.combine_provider_data(provider_lens_data, provider_configs)
-      
+
       eq({
-        [1] = { "line1_first", "line1_second" },
-        [2] = { "line2_first" },
-        [3] = { "line3_only" }
+        [1] = { { text = "line1_first" }, { text = "line1_second" } },
+        [2] = { { text = "line2_first" } },
+        [3] = { { text = "line3_only" } }
       }, result)
+    end)
+
+    describe("highlight resolution", function()
+      for _, tc in ipairs({
+        {
+          name = "result highlight is used",
+          lens_data = { prov = { { line = 1, text = "hi", highlight = "Special" } } },
+          configs = { { name = "prov", enabled = true } },
+          expected = { [1] = { { text = "hi", highlight = "Special" } } }
+        },
+        {
+          name = "provider config highlight as fallback",
+          lens_data = { prov = { { line = 1, text = "hi" } } },
+          configs = { { name = "prov", enabled = true, highlight = "Warning" } },
+          expected = { [1] = { { text = "hi", highlight = "Warning" } } }
+        },
+        {
+          name = "result highlight overrides provider config",
+          lens_data = { prov = { { line = 1, text = "hi", highlight = "Error" } } },
+          configs = { { name = "prov", enabled = true, highlight = "Warning" } },
+          expected = { [1] = { { text = "hi", highlight = "Error" } } }
+        },
+        {
+          name = "no highlight returns nil (global fallback applied at render time)",
+          lens_data = { prov = { { line = 1, text = "hi" } } },
+          configs = { { name = "prov", enabled = true } },
+          expected = { [1] = { { text = "hi" } } }
+        },
+        {
+          name = "empty string highlight treated as nil",
+          lens_data = { prov = { { line = 1, text = "hi", highlight = "" } } },
+          configs = { { name = "prov", enabled = true, highlight = "" } },
+          expected = { [1] = { { text = "hi" } } }
+        },
+        {
+          name = "empty result highlight falls back to provider config",
+          lens_data = { prov = { { line = 1, text = "hi", highlight = "" } } },
+          configs = { { name = "prov", enabled = true, highlight = "Warning" } },
+          expected = { [1] = { { text = "hi", highlight = "Warning" } } }
+        },
+        {
+          name = "same provider different per-result highlights",
+          lens_data = { refs = {
+            { line = 1, text = "5 refs", highlight = "LensGreen" },
+            { line = 2, text = "0 refs", highlight = "LensRed" },
+          } },
+          configs = { { name = "refs", enabled = true } },
+          expected = {
+            [1] = { { text = "5 refs", highlight = "LensGreen" } },
+            [2] = { { text = "0 refs", highlight = "LensRed" } }
+          }
+        },
+      }) do
+        it(tc.name, function()
+          local presenter = require("lensline.presenter")
+          local result = presenter.combine_provider_data(tc.lens_data, tc.configs)
+          eq(tc.expected, result)
+        end)
+      end
     end)
   end)
 
@@ -161,7 +215,7 @@ describe("presenter", function()
         local presenter = require("lensline.presenter")
         local args = { texts = { "test text" } }
         local result = presenter.compute_extmark_opts(args)
-        
+
         eq({
           virt_lines = { { { "test text", "Comment" } } },
           virt_lines_above = true,
@@ -177,11 +231,11 @@ describe("presenter", function()
           separator = " | ",
           highlight = "Error"
         }
-        
+
         local result = presenter.compute_extmark_opts(args)
-        
+
         eq({
-          virt_lines = { { { "text1 | text2", "Error" } } },
+          virt_lines = { { { "text1", "Error" }, { " | ", "Error" }, { "text2", "Error" } } },
           virt_lines_above = true,
           ephemeral = false
         }, result)
@@ -194,11 +248,11 @@ describe("presenter", function()
           prefix = ">> ",
           highlight = "Warning"
         }
-        
+
         local result = presenter.compute_extmark_opts(args)
-        
+
         eq({
-          virt_lines = { { { ">> test", "Warning" } } },
+          virt_lines = { { { ">> ", "Warning" }, { "test", "Warning" } } },
           virt_lines_above = true,
           ephemeral = false
         }, result)
@@ -211,13 +265,14 @@ describe("presenter", function()
           line_content = "    function foo()",
           prefix = "| "
         }
-        
+
         local result = presenter.compute_extmark_opts(args)
-        
+
         eq({
           virt_lines = { {
             { "    ", "Comment" },
-            { "| test", "Comment" }
+            { "| ", "Comment" },
+            { "test", "Comment" }
           } },
           virt_lines_above = true,
           ephemeral = false
@@ -230,11 +285,11 @@ describe("presenter", function()
           texts = { "test" },
           line_content = "\t  function foo()"
         }
-        
+
         local result = presenter.compute_extmark_opts(args)
-        
+
         eq({
-          virt_lines = { { 
+          virt_lines = { {
             { "\t  ", "Comment" },
             { "test", "Comment" }
           } },
@@ -249,9 +304,9 @@ describe("presenter", function()
           texts = { "test" },
           ephemeral = true
         }
-        
+
         local result = presenter.compute_extmark_opts(args)
-        
+
         assert.is_true(result.ephemeral)
       end)
     end)
@@ -263,11 +318,11 @@ describe("presenter", function()
           placement = "inline",
           texts = { "test" }
         }
-        
+
         local result = presenter.compute_extmark_opts(args)
-        
+
         eq({
-          virt_text = { { " test", "Comment" } },
+          virt_text = { { " ", "Comment" }, { "test", "Comment" } },
           virt_text_pos = "eol",
           hl_mode = "combine",
           ephemeral = false
@@ -281,11 +336,11 @@ describe("presenter", function()
           texts = { "test" },
           prefix = ">> "
         }
-        
+
         local result = presenter.compute_extmark_opts(args)
-        
+
         eq({
-          virt_text = { { " >> test", "Comment" } },
+          virt_text = { { " >> ", "Comment" }, { "test", "Comment" } },
           virt_text_pos = "eol",
           hl_mode = "combine",
           ephemeral = false
@@ -299,11 +354,11 @@ describe("presenter", function()
           texts = { "first", "second" },
           separator = " • "
         }
-        
+
         local result = presenter.compute_extmark_opts(args)
-        
+
         eq({
-          virt_text = { { " first • second", "Comment" } },
+          virt_text = { { " ", "Comment" }, { "first", "Comment" }, { " • ", "Comment" }, { "second", "Comment" } },
           virt_text_pos = "eol",
           hl_mode = "combine",
           ephemeral = false
@@ -317,11 +372,11 @@ describe("presenter", function()
           texts = { "test" },
           line_content = "    indented line"
         }
-        
+
         local result = presenter.compute_extmark_opts(args)
-        
+
         eq({
-          virt_text = { { " test", "Comment" } },
+          virt_text = { { " ", "Comment" }, { "test", "Comment" } },
           virt_text_pos = "eol",
           hl_mode = "combine",
           ephemeral = false
@@ -330,7 +385,6 @@ describe("presenter", function()
     end)
 
     describe("edge cases", function()
-      -- table-driven tests for edge cases
       for _, tc in ipairs({
         {
           name = "empty texts",
@@ -366,6 +420,141 @@ describe("presenter", function()
           eq(tc.expected, result)
         end)
       end
+    end)
+
+    describe("per-chunk highlights", function()
+      it("renders distinct highlights for above placement", function()
+        local presenter = require("lensline.presenter")
+        local result = presenter.compute_extmark_opts({
+          texts = {
+            { text = "5 refs", highlight = "Special" },
+            { text = "L complexity", highlight = "Warning" }
+          },
+          separator = " • ",
+          highlight = "Comment"
+        })
+
+        eq({
+          virt_lines = { {
+            { "5 refs", "Special" },
+            { " • ", "Comment" },
+            { "L complexity", "Warning" }
+          } },
+          virt_lines_above = true,
+          ephemeral = false
+        }, result)
+      end)
+
+      it("renders distinct highlights for inline placement", function()
+        local presenter = require("lensline.presenter")
+        local result = presenter.compute_extmark_opts({
+          placement = "inline",
+          texts = {
+            { text = "5 refs", highlight = "Special" },
+            { text = "L complexity", highlight = "Warning" }
+          },
+          separator = " • ",
+          highlight = "Comment"
+        })
+
+        eq({
+          virt_text = {
+            { " ", "Comment" },
+            { "5 refs", "Special" },
+            { " • ", "Comment" },
+            { "L complexity", "Warning" }
+          },
+          virt_text_pos = "eol",
+          hl_mode = "combine",
+          ephemeral = false
+        }, result)
+      end)
+
+      it("falls back to global highlight for chunks without highlight", function()
+        local presenter = require("lensline.presenter")
+        local result = presenter.compute_extmark_opts({
+          texts = {
+            { text = "no hl" },
+            { text = "has hl", highlight = "DiagWarn" }
+          },
+          separator = " | ",
+          highlight = "Comment"
+        })
+
+        eq({
+          virt_lines = { {
+            { "no hl", "Comment" },
+            { " | ", "Comment" },
+            { "has hl", "DiagWarn" }
+          } },
+          virt_lines_above = true,
+          ephemeral = false
+        }, result)
+      end)
+
+      it("separator always uses global highlight", function()
+        local presenter = require("lensline.presenter")
+        local result = presenter.compute_extmark_opts({
+          texts = {
+            { text = "a", highlight = "Hl1" },
+            { text = "b", highlight = "Hl2" }
+          },
+          separator = " | ",
+          highlight = "Comment"
+        })
+
+        eq(result.virt_lines[1][2], { " | ", "Comment" })
+      end)
+
+      it("prefix always uses global highlight", function()
+        local presenter = require("lensline.presenter")
+        local result = presenter.compute_extmark_opts({
+          texts = { { text = "test", highlight = "Special" } },
+          prefix = "┃ ",
+          highlight = "Comment"
+        })
+
+        eq({
+          virt_lines = { {
+            { "┃ ", "Comment" },
+            { "test", "Special" }
+          } },
+          virt_lines_above = true,
+          ephemeral = false
+        }, result)
+      end)
+
+      it("prefix uses global highlight for inline placement", function()
+        local presenter = require("lensline.presenter")
+        local result = presenter.compute_extmark_opts({
+          placement = "inline",
+          texts = { { text = "test", highlight = "Special" } },
+          prefix = "┃ ",
+          highlight = "Comment"
+        })
+
+        eq(result.virt_text[1], { " ┃ ", "Comment" })
+        eq(result.virt_text[2], { "test", "Special" })
+      end)
+
+      it("backward compat with plain string texts", function()
+        local presenter = require("lensline.presenter")
+        local result = presenter.compute_extmark_opts({
+          texts = { "plain1", "plain2" },
+          separator = " • ",
+          highlight = "Comment"
+        })
+
+        eq({
+          virt_lines = { {
+            { "plain1", "Comment" },
+            { " • ", "Comment" },
+            { "plain2", "Comment" }
+          } },
+          virt_lines_above = true,
+          ephemeral = false
+        }, result)
+      end)
     end)
   end)
 end)


### PR DESCRIPTION
## Summary
- Add per-provider and per-result highlight groups with fallback chain (result → provider config → global `style.highlight`)
- Separator and prefix always use global highlight; fully backward compatible
- Documentation added to README (config reference + style example) and providers.md (callback API + fallback chain)
- Changelog updated, version bumped to v2.1.0

Closes #88